### PR TITLE
Consistent image name for overwriting

### DIFF
--- a/mysite/flask_app.py
+++ b/mysite/flask_app.py
@@ -44,7 +44,7 @@ def home():
             return redirect(request.url)
 
         if file and allowed_file(file.filename):
-            filename = secure_filename(file.filename)
+            filename = "results.jpg"
             file.save(os.path.join(app.config['UPLOAD_FOLDER'], filename))
             return redirect(url_for('uploaded_file',
                                     filename=filename))


### PR DESCRIPTION
Since the formats .png .jpg and .jpeg all use the same display format, changing the extension allows the image to still be readable. This avoids any issue with multiple extensions.
The simplest way to do this lol